### PR TITLE
add build binary script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,13 @@
 # limitations under the License.
 
 FROM golang:1.12-alpine as builder
-
-ENV PKG_NAME=github.com/intel/network-resources-injector
-ENV PKG_PATH=$GOPATH/src/$PKG_NAME
-WORKDIR $PKG_PATH
-
-COPY . $PKG_PATH/
-RUN go install ./cmd/...
+ADD . /usr/src/network-resources-injector
+RUN apk add --update --virtual build-dependencies build-base linux-headers && \
+    cd /usr/src/network-resources-injector && \
+    make
 
 FROM golang:1.12-alpine
-COPY --from=builder /go/bin/webhook /go/bin/installer /usr/bin/
+COPY --from=builder /usr/src/network-resources-injector/bin/webhook /usr/bin/
+COPY --from=builder /usr/src/network-resources-injector/bin/installer /usr/bin/
 
 CMD ["webhook"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,14 +1,10 @@
 FROM openshift/origin-release:golang-1.10 as builder
-
-ENV PKG_NAME=github.com/intel/network-resources-injector
-ENV PKG_PATH=$GOPATH/src/$PKG_NAME
-WORKDIR $PKG_PATH
-
-COPY . $PKG_PATH/
-RUN go install ./cmd/...
+ADD . /usr/src/network-resources-injector
+RUN cd /usr/src/network-resources-injector && make
 
 FROM openshift/origin-base
-COPY --from=builder /go/bin/webhook /go/bin/installer /usr/bin/
+COPY --from=builder /usr/src/network-resources-injector/bin/webhook /usr/bin/
+COPY --from=builder /usr/src/network-resources-injector/bin/installer /usr/bin/
 
 LABEL io.k8s.display-name="SRIOV Admission Controller"
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@
 default :
 	scripts/build.sh
 
+image :
+	scripts/build-image.sh
+
 test :
 	export t="/tmp/go-cover.$$.tmp" && go test -coverprofile=$t ./... && go tool cover -html=$t
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Network Resources Injector is a Kubernetes Dynamic Admission Controller applicat
 
 To quickly build and deploy admission controller run:
 ```
-make
+make image
 kubectl apply -f deployments/auth.yaml \
               -f deployments/server.yaml
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 Go to the root directory of the Network Resources Injector and build image:
 ```
 cd $GOPATH/src/github.com/intel/network-resources-injector
-make
+make image
 ```
 
 ## Deploying webhook application

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: Execute only from the package root directory or top-level Makefile!
+
+set -e
+
+# build admission controller Docker image
+docker build --build-arg http_proxy=${http_proxy} \
+             --build-arg HTTP_PROXY=${HTTP_PROXY} \
+             --build-arg https_proxy=${https_proxy} \
+             --build-arg HTTPS_PROXY=${HTTPS_PROXY} \
+             --build-arg no_proxy=${no_proxy} \
+             --build-arg NO_PROXY=${NO_PROXY} \
+             -f Dockerfile \
+             -t network-resources-injector .

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,29 +1,17 @@
-#!/usr/bin/env bash
-
-# Copyright (c) 2019 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http:#www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Note: Execute only from the package root directory or top-level Makefile!
-
 set -e
 
-# build admission controller Docker image
-docker build --build-arg http_proxy=${http_proxy} \
-             --build-arg HTTP_PROXY=${HTTP_PROXY} \
-             --build-arg https_proxy=${https_proxy} \
-             --build-arg HTTPS_PROXY=${HTTPS_PROXY} \
-             --build-arg no_proxy=${no_proxy} \
-             --build-arg NO_PROXY=${NO_PROXY} \
-             -f Dockerfile \
-             -t network-resources-injector .
+ORG_PATH="github.com/intel"
+REPO_PATH="${ORG_PATH}/network-resources-injector"
+
+if [ ! -h .gopath/src/${REPO_PATH} ]; then
+	mkdir -p .gopath/src/${ORG_PATH}
+	ln -s ../../../.. .gopath/src/${REPO_PATH} || exit 255
+fi
+
+export GOPATH=${PWD}/.gopath
+export GOBIN=${PWD}/bin
+export CGO_ENABLED=0
+export GO15VENDOREXPERIMENT=1
+
+go install -tags no_openssl "$@" ${REPO_PATH}/cmd/installer
+go install -tags no_openssl "$@" ${REPO_PATH}/cmd/webhook


### PR DESCRIPTION
This also defaults `make` to build binary instead of
image; To build container image, run image build
explicitly `make image`.