### PR TITLE
Update for k8s 1.18 version

### DIFF
--- a/deployments/auth.yaml
+++ b/deployments/auth.yaml
@@ -51,6 +51,7 @@ rules:
   resources:
   - certificatesigningrequests
   - certificatesigningrequests/approval
+  - signers
   verbs:
   - '*'
 ---

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -271,17 +271,17 @@ func patchEmptyResources(patch []jsonPatchOperation, containerIndex uint, key st
 
 func addVolDownwardAPI(patch []jsonPatchOperation) []jsonPatchOperation {
 	labels := corev1.ObjectFieldSelector{
-		FieldPath:"metadata.labels",
+		FieldPath: "metadata.labels",
 	}
 	dAPILabels := corev1.DownwardAPIVolumeFile{
-		Path: "labels",
+		Path:     "labels",
 		FieldRef: &labels,
 	}
 	annotations := corev1.ObjectFieldSelector{
-		FieldPath:"metadata.annotations",
+		FieldPath: "metadata.annotations",
 	}
 	dAPIAnnotations := corev1.DownwardAPIVolumeFile{
-		Path: "annotations",
+		Path:     "annotations",
 		FieldRef: &annotations,
 	}
 	dAPIItems := []corev1.DownwardAPIVolumeFile{dAPILabels, dAPIAnnotations}
@@ -292,14 +292,14 @@ func addVolDownwardAPI(patch []jsonPatchOperation) []jsonPatchOperation {
 		DownwardAPI: &dAPIVolSource,
 	}
 	vol := corev1.Volume{
-		Name: "podnetinfo",
+		Name:         "podnetinfo",
 		VolumeSource: volSource,
 	}
 
 	patch = append(patch, jsonPatchOperation{
 		Operation: "add",
 		Path:      "/spec/volumes/-",
-		Value:    vol,
+		Value:     vol,
 	})
 
 	return patch
@@ -308,15 +308,15 @@ func addVolDownwardAPI(patch []jsonPatchOperation) []jsonPatchOperation {
 func addVolumeMount(patch []jsonPatchOperation) []jsonPatchOperation {
 
 	vm := corev1.VolumeMount{
-		Name: "podnetinfo",
-		ReadOnly: false,
+		Name:      "podnetinfo",
+		ReadOnly:  false,
 		MountPath: "/etc/podnetinfo",
 	}
 
 	patch = append(patch, jsonPatchOperation{
 		Operation: "add",
 		Path:      "/spec/containers/0/volumeMounts/-", // NOTE: in future we may want to patch specific container (not always the first one)
-		Value:      vm,
+		Value:     vm,
 	})
 
 	return patch
@@ -424,6 +424,10 @@ func MutateHandler(w http.ResponseWriter, req *http.Request) {
 
 			patchBytes, _ := json.Marshal(patch)
 			ar.Response.Patch = patchBytes
+			ar.Response.PatchType = func() *v1beta1.PatchType {
+				pt := v1beta1.PatchTypeJSONPatch
+				return &pt
+			}()
 		}
 	} else {
 		/* network annotation not provided or empty */


### PR DESCRIPTION
1. Add signers for the init container because signers are needed for CSRs. 
This is mandatory for k8s 1.18 version as per below [PR](https://github.com/kubernetes/kubernetes/pull/86933).

2. Add Response.PatchType into AdmissionReview as it would be needed
for some versions of k8s 1.18 deployment

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>