### PR TITLE
add default handler for getting ownerReference

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -199,6 +199,10 @@ func getNamespaceFromOwnerReference(ownerRef metav1.OwnerReference) (namespace s
 				break
 			}
 		}
+	default:
+		glog.Infof("owner reference kind is not supported: %v, using default namespace", ownerRef.Kind)
+		namespace = "default"
+		return
 	}
 
 	if namespace == "" {


### PR DESCRIPTION
Without default handler, network-resources-injector rejects the pod
creation from any unsupported Kind.