### PR TITLE
Add failure if parsing networks failed

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -429,7 +429,11 @@ func MutateHandler(w http.ResponseWriter, req *http.Request) {
 		resourceRequests := make(map[string]int64)
 
 		/* unmarshal list of network selection objects */
-		networks, _ := parsePodNetworkSelections(netSelections, pod.ObjectMeta.Namespace)
+		networks, err := parsePodNetworkSelections(netSelections, pod.ObjectMeta.Namespace)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 
 		for _, n := range networks {
 			/* for each network in annotation ask API server for network-attachment-definition */


### PR DESCRIPTION
* Return bad request if we cannot parse network
  annotation

* Previous to this patch, it was ignored and pod would
  be scheduled

Signed-off-by: Kennelly, Martin <martin.kennelly@intel.com>