### PR TITLE
retrieve ca client bundle from extension api server config map

### DIFF
--- a/scripts/webhook-patch-ca-bundle.sh
+++ b/scripts/webhook-patch-ca-bundle.sh
@@ -7,7 +7,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 -w=0)
+export CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 --w=0)
 
 if command -v envsubst >/dev/null 2>&1; then
     envsubst


### PR DESCRIPTION
This change updates the script with appropriate command so that
ca cert bundle is retrieved properly so that mutating admission
webhook can be configured correctly.

The current one throws below error.
```
# kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 -w=0
base64: invalid wrap size: ‘=0’
```

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>